### PR TITLE
Breaking - Convert CamelCase to snake_case

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -68,7 +68,7 @@ class FrankEnergie:
         self._auth = Authentication.from_dict(await self._query(query))
         return self._auth
 
-    async def renewToken(self, authToken: str, refreshToken: str) -> Authentication:
+    async def renew_token(self, auth_token: str, refresh_token: str) -> Authentication:
         """Renew the authentication token."""
         query = {
             "query": """
@@ -80,7 +80,7 @@ class FrankEnergie:
                 }
             """,
             "operationName": "RenewToken",
-            "variables": {"authToken": authToken, "refreshToken": refreshToken},
+            "variables": {"authToken": auth_token, "refreshToken": refresh_token},
         }
 
         json = await self._query(query)
@@ -89,7 +89,7 @@ class FrankEnergie:
         self._auth = Authentication.from_dict(json)
         return self._auth
 
-    async def monthSummary(self) -> MonthSummary:
+    async def month_summary(self) -> MonthSummary:
         """Get month summary data."""
         if self._auth is None:
             raise AuthRequiredException
@@ -195,7 +195,7 @@ class FrankEnergie:
 
         return MarketPrices.from_dict(await self._query(query_data))
 
-    async def userPrices(self, start_date: date) -> MarketPrices:
+    async def user_prices(self, start_date: date) -> MarketPrices:
         """Get customer market prices."""
         if self._auth is None:
             raise AuthRequiredException

--- a/tests/test_frank_energie.py
+++ b/tests/test_frank_energie.py
@@ -118,7 +118,7 @@ async def test_renew_token(aresponses):
 
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session)
-        auth = await api.renewToken("a", "b")  # noqa: S106
+        auth = await api.renew_token("a", "b")  # noqa: S106
         await api.close()
 
     assert api.is_authenticated is True
@@ -143,7 +143,7 @@ async def test_renew_token_invalid_credentials(aresponses):
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session)
         with pytest.raises(AuthException):
-            await api.renewToken("a", "b")  # noqa: S106
+            await api.renew_token("a", "b")  # noqa: S106
         await api.close()
 
 
@@ -164,7 +164,7 @@ async def test_renew_token_invalid_response(aresponses):
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session)
         with pytest.raises(AuthException):
-            await api.renewToken("a", "b")  # noqa: S106
+            await api.renew_token("a", "b")  # noqa: S106
         await api.close()
 
 
@@ -189,7 +189,7 @@ async def test_month_summary(aresponses):
 
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session, auth_token="a", refresh_token="b")  # noqa: S106
-        summary = await api.monthSummary()
+        summary = await api.month_summary()
         await api.close()
 
     assert summary is not None
@@ -208,7 +208,7 @@ async def test_month_summary_without_authentication(aresponses):
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session)
         with pytest.raises(AuthRequiredException):
-            await api.monthSummary()
+            await api.month_summary()
         await api.close()
 
 
@@ -361,7 +361,7 @@ async def test_user_prices(aresponses):
 
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session, auth_token="a", refresh_token="b")  # noqa: S106
-        prices = await api.userPrices(datetime.utcnow().date())
+        prices = await api.user_prices(datetime.utcnow().date())
         await api.close()
 
     assert prices.electricity is not None


### PR DESCRIPTION
Use more common snake_case for methods.

We keep the model variables in camelCase to keep them in sync with the Frank Energie API