### PR TITLE
Add listing for SmartBatteries and related tests

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -9,7 +9,14 @@ from typing import Any
 from aiohttp.client import ClientError, ClientSession
 
 from .exceptions import AuthException, AuthRequiredException
-from .models import Authentication, Invoices, MarketPrices, Me, MonthSummary
+from .models import (
+    Authentication,
+    Invoices,
+    MarketPrices,
+    Me,
+    MonthSummary,
+    SmartBatteries,
+)
 
 
 class FrankEnergie:
@@ -483,6 +490,49 @@ class FrankEnergie:
         }
 
         return MarketPrices.from_userprices_dict(await self._query(query_data))
+
+    async def smart_batteries(self) -> SmartBatteries:
+        """Get the users smart batteries.
+
+        Returns a list of all smart batteries.
+
+        Full query:
+        query {
+          smartBatteries {
+            brand
+            capacity
+            createdAt
+            externalReference
+            id
+            maxChargePower
+            maxDischargePower
+            provider
+            updatedAt
+          }
+        }
+        """
+        if self._auth is None:
+            raise AuthRequiredException
+
+        query = {
+            "query": """
+                    query {
+                      smartBatteries {
+                        brand
+                        capacity
+                        createdAt
+                        externalReference
+                        id
+                        maxChargePower
+                        maxDischargePower
+                        provider
+                        updatedAt
+                      }
+                """,
+            "operationName": "SmartBatteries",
+        }
+
+        return SmartBatteries.from_dict(await self._query(query))
 
     @property
     def is_authenticated(self) -> bool:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -423,7 +423,7 @@ class MarketPrices:
 
 @dataclass
 class SmartBatteries:
-    """Collection of the users SmartBatteries"""
+    """Collection of the users SmartBatteries."""
 
     smart_batteries: list[SmartBattery]
 
@@ -448,6 +448,7 @@ class SmartBatteries:
 
     @dataclass
     class SmartBattery:
+        """SmartBattery model."""
 
         brand: str
         capacity: float
@@ -461,7 +462,7 @@ class SmartBatteries:
 
         @staticmethod
         def from_dict(payload: dict[str, str]) -> SmartBatteries.SmartBattery:
-            """Parse the response from the me query."""
+            """Parse the response from the SmartBatteries query."""
             _LOGGER.debug("DeliverySites %s", payload)
 
             return SmartBatteries.SmartBattery(

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -419,3 +419,59 @@ class MarketPrices:
             electricity=PriceData(customerMarketPrices.get("electricityPrices")),
             gas=PriceData(customerMarketPrices.get("gasPrices")),
         )
+
+
+@dataclass
+class SmartBatteries:
+    """Collection of the users SmartBatteries"""
+
+    smart_batteries: list[SmartBattery]
+
+    @staticmethod
+    def from_dict(data: dict[str, str]) -> SmartBatteries:
+        """Parse the response from the smartBatteries query."""
+        _LOGGER.debug("SmartBatteries %s", data)
+
+        if errors := data.get("errors"):
+            raise RequestException(errors[0]["message"])
+
+        payload = data.get("data")
+        if not payload:
+            raise RequestException("Unexpected response")
+
+        return SmartBatteries(
+            smart_batteries=[
+                SmartBatteries.SmartBattery.from_dict(smart_battery)
+                for smart_battery in payload.get("smartBatteries")
+            ],
+        )
+
+    @dataclass
+    class SmartBattery:
+
+        brand: str
+        capacity: float
+        external_reference: str
+        id: str
+        max_charge_power: float
+        max_discharge_power: float
+        provider: str
+        created_at: datetime
+        updated_at: datetime
+
+        @staticmethod
+        def from_dict(payload: dict[str, str]) -> SmartBatteries.SmartBattery:
+            """Parse the response from the me query."""
+            _LOGGER.debug("DeliverySites %s", payload)
+
+            return SmartBatteries.SmartBattery(
+                brand=payload.get("brand"),
+                capacity=payload.get("capacity"),
+                external_reference=payload.get("externalReference"),
+                id=payload.get("id"),
+                max_charge_power=payload.get("maxChargePower"),
+                max_discharge_power=payload.get("maxDischargePower"),
+                provider=payload.get("provider"),
+                created_at=payload.get("createdAt"),
+                updated_at=payload.get("updatedAt"),
+            )

--- a/tests/__snapshots__/test_smart_batteries.ambr
+++ b/tests/__snapshots__/test_smart_batteries.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_smart_batteries
+  SmartBatteries(smart_batteries=[SmartBatteries.SmartBattery(brand='SESSY', capacity=5.2, external_reference='SESSYREF', id='unique_identifier', max_charge_power=2.2, max_discharge_power=1.7, provider='SESSY', created_at='2024-04-30T13:33:42.776Z', updated_at='2024-05-29T08:55:58.270Z')])
+# ---

--- a/tests/fixtures/smart_batteries.json
+++ b/tests/fixtures/smart_batteries.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "smartBatteries": [
+      {
+        "brand": "SESSY",
+        "capacity": 5.2,
+        "createdAt": "2024-04-30T13:33:42.776Z",
+        "externalReference": "SESSYREF",
+        "id": "unique_identifier",
+        "maxChargePower": 2.2,
+        "maxDischargePower": 1.7,
+        "provider": "SESSY",
+        "updatedAt": "2024-05-29T08:55:58.270Z"
+      }
+    ]
+  }
+}

--- a/tests/test_smart_batteries.py
+++ b/tests/test_smart_batteries.py
@@ -1,0 +1,32 @@
+import aiohttp
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from python_frank_energie import FrankEnergie
+
+from . import load_fixtures
+
+SIMPLE_DATA_URL = "frank-graphql-prod.graphcdn.app"
+
+
+@pytest.mark.asyncio
+async def test_smart_batteries(aresponses, snapshot: SnapshotAssertion):
+    """Test request with authentication."""
+    aresponses.add(
+        SIMPLE_DATA_URL,
+        "/",
+        "POST",
+        aresponses.Response(
+            text=load_fixtures("smart_batteries.json"),
+            status=200,
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        api = FrankEnergie(session, auth_token="a", refresh_token="b")  # noqa: S106
+        smart_batteries = await api.smart_batteries()
+        await api.close()
+
+    assert smart_batteries is not None
+    assert smart_batteries == snapshot

--- a/tests/test_smart_batteries.py
+++ b/tests/test_smart_batteries.py
@@ -1,3 +1,4 @@
+"""Tests for Frank Energie Smart batteries implementation.""" 
 import aiohttp
 import pytest
 from syrupy.assertion import SnapshotAssertion

--- a/tests/test_smart_batteries.py
+++ b/tests/test_smart_batteries.py
@@ -1,4 +1,5 @@
 """Tests for Frank Energie Smart batteries implementation."""
+
 import aiohttp
 import pytest
 from syrupy.assertion import SnapshotAssertion

--- a/tests/test_smart_batteries.py
+++ b/tests/test_smart_batteries.py
@@ -1,4 +1,4 @@
-"""Tests for Frank Energie Smart batteries implementation.""" 
+"""Tests for Frank Energie Smart batteries implementation."""
 import aiohttp
 import pytest
 from syrupy.assertion import SnapshotAssertion


### PR DESCRIPTION
This PR adds a new method to the API to list the current users connected batteries, for example the Sessy.

If you see something let me know :-) I'm not a python dev by day (or night)

In a next PR I will add a method to get the 'earnings' per connected Smart Battery of the user.
