### PR TITLE
poetry.group.dev.dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ python-dateutil = ">=2.8.0"
 PyJWT = ">=2.8.0"
 syrupy = "^4.6.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 aresponses = "^3.0.0"
 black = "^24.8"
 blacken-docs = "^1.19.1"


### PR DESCRIPTION
Changed deprecated poetry.dev.dependencies to poetry.group.dev.dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration format for development dependencies, aligning with modern dependency management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->